### PR TITLE
Added auth_message and small changes

### DIFF
--- a/src/econ.rs
+++ b/src/econ.rs
@@ -43,8 +43,8 @@ impl Econ {
     }
 
     /// Change auth message
-    pub fn set_auth_message(&mut self, auth_message: String) {
-        self.raw.as_mut().unwrap().set_auth_message(auth_message)
+    pub fn set_auth_message<T: ToString>(&mut self, auth_message: T) {
+        self.raw.as_mut().unwrap().set_auth_message(auth_message.to_string());
     }
 
     /// Blocking *write* operation, sends line to socket

--- a/src/econ.rs
+++ b/src/econ.rs
@@ -2,13 +2,14 @@ use std::net::SocketAddr;
 
 use crate::raw::EconRaw;
 
+#[derive(Default)]
 pub struct Econ {
     raw: Option<EconRaw>,
 }
 
 impl Econ {
     pub fn new() -> Self {
-        Self { raw: None }
+        Self::default()
     }
 
     /// Connects to given address
@@ -38,7 +39,12 @@ impl Econ {
 
         let raw = self.raw.as_mut().unwrap();
 
-        Ok(raw.auth(password.into().as_str())?)
+        raw.auth(password.into().as_str())
+    }
+
+    /// Change auth message
+    pub fn set_auth_message(&mut self, auth_message: String) {
+        self.raw.as_mut().unwrap().set_auth_message(auth_message)
     }
 
     /// Blocking *write* operation, sends line to socket
@@ -69,7 +75,7 @@ impl Econ {
 
         let raw = self.raw.as_mut().unwrap();
 
-        if fetch == true {
+        if fetch {
             assert!(
                 raw.is_authed(),
                 "you can't fetch lines without being authed"

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -8,6 +8,7 @@ pub struct EconRaw {
     lines: Vec<String>,
     unfinished_line: String,
     authed: bool,
+    auth_message: String,
 }
 
 impl EconRaw {
@@ -27,11 +28,16 @@ impl EconRaw {
             lines: Vec::new(),
             unfinished_line: String::new(),
             authed: false,
+            auth_message: "Authentication successful".to_string()
         })
     }
 
     pub fn disconnect(&mut self) -> std::io::Result<()> {
         self.socket.shutdown(Shutdown::Both)
+    }
+
+    pub fn set_auth_message(&mut self, auth_message: String) {
+        self.auth_message = auth_message
     }
 
     pub fn auth(&mut self, password: &str) -> std::io::Result<bool> {
@@ -43,7 +49,7 @@ impl EconRaw {
         self.read()?;
 
         while let Some(line) = self.pop_line() {
-            if line.starts_with("Authentication successful") {
+            if line.starts_with(self.auth_message.as_str()) {
                 self.authed = true;
             }
         }


### PR DESCRIPTION
Added ability to modify auth_message 
Slightly modified the code, removed unnecessary elements

The reason for adding this feature is user modes that do not display the “Authentication Successful” message at the beginning.

The code has been tested